### PR TITLE
self keyword and scope resolution operator

### DIFF
--- a/application/libraries/Shopify.php
+++ b/application/libraries/Shopify.php
@@ -146,7 +146,7 @@ class Shopify{
     {
 	    if ($verifyData)
 	    {
-		    foreach (self::$_KEYS as $k)
+		    foreach ($this->_KEYS as $k)
 		    {
 			    if ((!array_key_exists($k, $this->_API)) || (empty($this->_API[$k])))
 			    {


### PR DESCRIPTION
Resolved issue of $_KEYS, on line 149 of shopify library which we are using, self keyword and scope resolution operator , replaced with $this->_KEYS.